### PR TITLE
chore: add agent workflow, worktree helper, and Backlog taskboard

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,37 @@
+
+<!-- BACKLOG.MD GUIDELINES START -->
+<!-- backlog.md-instructions-version: 1.48.0 -->
+<CRITICAL_INSTRUCTION>
+
+## Backlog.md Workflow
+
+This project uses Backlog.md for task and project management.
+
+**For every user request in this project, run `backlog instructions overview` before answering or taking action.**
+
+Use the overview to decide whether to search, read, create, or update Backlog tasks.
+
+Before task lifecycle actions, read the matching detailed guide:
+- `backlog instructions task-creation` before creating or splitting tasks
+- `backlog instructions task-execution` before planning, changing status or assignee, adding a plan or implementation notes, or implementing task work
+- `backlog instructions task-finalization` before checking acceptance criteria, writing final summaries, or moving tasks to terminal statuses
+
+Use `backlog <command> --help` before running unfamiliar commands. Help shows options, fields, and examples.
+
+Do not edit Backlog task, draft, document, decision, or milestone markdown files directly. Use the `backlog` CLI so metadata, relationships, and history stay consistent.
+
+</CRITICAL_INSTRUCTION>
+<!-- BACKLOG.MD GUIDELINES END -->
+
+## Repository layout (READ FIRST)
+
+The repo root is a normal **git checkout of `master`**, with **linked worktrees** under
+`.worktrees/` for parallel task work:
+
+- The root is `master`'s working tree — `git status` and builds work here. Keep `master`
+  clean; **do task work in a worktree, not on `master` at the root**.
+- Create a task worktree with `./scripts/wt.sh <branch> --task TASK-N`
+  (or `git worktree add .worktrees/<branch> -b <branch> master`), then `cd` into it.
+- `.worktrees/` is gitignored. The taskboard is `backlog/` (use the `backlog` CLI).
+- See **`AGENTS.md`** at the repo root for the full layout and the
+  task → worktree → Backlog workflow.

--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,6 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# Local task worktrees (git worktree add)
+/.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md — connect-dotnet
+
+> This repo is a normal **git checkout of `master` at the root**, plus **linked worktrees**
+> under `.worktrees/` for parallel task work. Start at the root.
+
+## TL;DR for agents
+
+- **Start at the repo root.** The root is `master`'s working tree; the agent docs, taskboard,
+  and helper scripts live here and are version-controlled.
+- The **taskboard** is `backlog/` (Backlog.md). Check it before doing anything.
+- **Don't do task work directly on `master` at the root.** For each task, create a worktree
+  under `.worktrees/<branch>`, work there, finalize, PR, then remove it.
+- One worktree per task.
+
+## Layout
+
+```
+connect-dotnet/            <- ROOT: git checkout of `master` (start here)
+├── .git/                  <- normal git dir
+├── AGENTS.md              <- this file (tracked)
+├── scripts/wt.sh          <- helper: create a task worktree (tracked)
+├── backlog/               <- Backlog.md taskboard (tracked)
+├── .github/
+│   ├── copilot-instructions.md   <- agent nudge (tracked)
+│   └── workflows/                <- CI
+├── BusinessService/  LocationService/  RestAPI/  postgres/  redis/   <- services
+├── docker-compose.yml  MySolution.sln  README.md
+├── .worktrees/           <- linked task worktrees (gitignored, local)
+│   └── <branch>/
+└── .env                  <- secrets (gitignored)
+```
+
+`.worktrees/*` are linked worktrees that share history in `.git`. They are **gitignored** and
+local to your machine; their contents are committed via their own branch, never via `master`.
+
+## Taskboard: check / start / stop / finish
+
+Drive the board through the `backlog` CLI (never hand-edit files in `backlog/`).
+
+| Action | Command |
+| --- | --- |
+| See the board | `backlog board` |
+| List / filter | `backlog task list --plain` · `backlog task list -s "In Progress" --plain` |
+| View one | `backlog task view TASK-N --plain` |
+| **Start** | `backlog task edit TASK-N -s "In Progress" -a @you` |
+| **Stop / park** | `backlog task edit TASK-N -s "To Do"` |
+| Record progress | `backlog task edit TASK-N --append-notes "..."` |
+| **Finish** | (read the guide first) `backlog task edit TASK-N --check-ac 1 --final-summary "..." -s Done` |
+
+Read the guides before lifecycle actions: `backlog instructions overview`, then
+`task-creation` / `task-execution` / `task-finalization`.
+
+## Working a task (from the root)
+
+1. Pick a task from `backlog board`.
+2. Create its worktree + branch:
+   ```bash
+   ./scripts/wt.sh <branch> --base master --task TASK-N
+   # manual: git worktree add .worktrees/<branch> -b <branch> master
+   #         backlog task edit TASK-N -s "In Progress"
+   ```
+3. `cd .worktrees/<branch>` — do all code, build, and test work **here**.
+4. Record notes on the task as you go (`--append-notes`).
+5. Finalize per `backlog instructions task-finalization`; push the branch; open a PR; tie the
+   branch to the task (keep existing refs):
+   ```bash
+   backlog task edit TASK-N --ref "https://github.com/tpham2580/connect-dotnet/tree/<branch>"
+   ```
+6. After merge: `git worktree remove .worktrees/<branch> && git branch -d <branch>`.
+
+## Git notes
+
+- The root is a normal `master` checkout — `git status`, builds, and `git worktree ...` all
+  work here. Keep `master` clean; make task changes in a worktree, not at the root.
+- `.worktrees/` is gitignored, so task worktrees never appear in `master`'s status.
+- Keep shared agent files (`AGENTS.md`, `scripts/`, `backlog/`, `.github/copilot-instructions.md`)
+  updated on `master`, then rebase task branches on top to propagate them.
+
+## Orchestrator convention (Tmux Orchestrator → workers)
+
+- Run the orchestrator from the root.
+- For each task: create a worktree (`scripts/wt.sh`) and spawn **one worker per task**.
+- Brief every worker with: the **task ID**, its **worktree path** under `.worktrees/`, and
+  "start by reading `AGENTS.md` and running `backlog instructions overview`".
+- A worker sets its task **In Progress** on start, works only inside its worktree, and drives
+  the task to **Done** via the Backlog CLI. One task per worker; don't silently expand scope.

--- a/backlog/config.yml
+++ b/backlog/config.yml
@@ -1,0 +1,16 @@
+project_name: "Connect Dotnet"
+default_status: "To Do"
+statuses: ["To Do", "In Progress", "Done"]
+labels: []
+date_format: yyyy-mm-dd
+max_column_width: 20
+default_editor: "/usr/bin/nano"
+auto_open_browser: true
+default_port: 6420
+remote_operations: false
+auto_commit: false
+filesystem_only: true
+bypass_git_hooks: false
+check_active_branches: false
+active_branch_days: 30
+task_prefix: "task"

--- a/backlog/tasks/task-1 - Expose-BusinessService-via-REST-API.md
+++ b/backlog/tasks/task-1 - Expose-BusinessService-via-REST-API.md
@@ -1,0 +1,30 @@
+---
+id: TASK-1
+title: Expose BusinessService via REST API
+status: In Progress
+assignee: []
+created_date: '2026-07-23 01:58'
+updated_date: '2026-07-23 04:10'
+labels:
+  - backend
+  - api
+dependencies: []
+references:
+  - 'https://github.com/tpham2580/connect-dotnet/pull/42'
+  - 'https://github.com/tpham2580/connect-dotnet/tree/restapi-businessservice'
+priority: high
+ordinal: 1000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add REST endpoints (CRUD) for BusinessService so external clients can manage businesses over HTTP.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 GET /businesses returns paged results
+- [ ] #2 POST /businesses validates payload and returns 201
+- [ ] #3 Integration tests cover happy path and 400/404
+<!-- AC:END -->

--- a/backlog/tasks/task-2 - Add-Redis-caching-for-business-names.md
+++ b/backlog/tasks/task-2 - Add-Redis-caching-for-business-names.md
@@ -1,0 +1,26 @@
+---
+id: TASK-2
+title: Add Redis caching for business names
+status: To Do
+assignee: []
+created_date: '2026-07-23 01:58'
+labels:
+  - redis
+  - performance
+dependencies: []
+priority: medium
+ordinal: 2000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Cache business-name lookups in Redis to cut Postgres load on hot paths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Cache hit avoids DB query
+- [ ] #2 Keys use a versioned business: prefix
+- [ ] #3 TTL is configurable via env
+<!-- AC:END -->

--- a/backlog/tasks/task-3 - LocationService-geospatial-lookup-endpoint.md
+++ b/backlog/tasks/task-3 - LocationService-geospatial-lookup-endpoint.md
@@ -1,0 +1,24 @@
+---
+id: TASK-3
+title: 'LocationService: geospatial lookup endpoint'
+status: To Do
+assignee: []
+created_date: '2026-07-23 01:58'
+labels:
+  - backend
+  - locationservice
+dependencies: []
+ordinal: 3000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Expose an endpoint returning businesses within a radius of a lat/long.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Endpoint accepts lat, long, radiusKm
+- [ ] #2 Results sorted by distance ascending
+<!-- AC:END -->

--- a/backlog/tasks/task-4 - Pin-.NET-SDK-version-in-docker-compose.md
+++ b/backlog/tasks/task-4 - Pin-.NET-SDK-version-in-docker-compose.md
@@ -1,0 +1,30 @@
+---
+id: TASK-4
+title: Pin .NET SDK version in docker-compose
+status: Done
+assignee: []
+created_date: '2026-07-23 01:58'
+labels:
+  - devops
+dependencies: []
+references:
+  - 'https://github.com/tpham2580/connect-dotnet/pull/37'
+ordinal: 4000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pin the SDK image tag so local and CI builds are reproducible.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 docker-compose uses an explicit SDK tag
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Pinned SDK to 8.0.x across compose files; verified clean build.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-5 - Fix-non-functional-ItemsController-in-RestAPI.md
+++ b/backlog/tasks/task-5 - Fix-non-functional-ItemsController-in-RestAPI.md
@@ -1,0 +1,26 @@
+---
+id: TASK-5
+title: Fix non-functional ItemsController in RestAPI
+status: To Do
+assignee: []
+created_date: '2026-07-23 04:10'
+labels:
+  - restapi
+  - bug
+dependencies: []
+priority: medium
+ordinal: 5000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+RestAPI ItemsController has a private constructor and a private GetById action, so the endpoint is not routable and DI cannot activate it. IItemService/ItemService are never registered in Program.cs and the in-memory store is always empty. Make the members public and register the service, or remove the dead feature.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Controller constructor and GetById action are public and reachable via routing
+- [ ] #2 IItemService is registered in DI in Program.cs
+- [ ] #3 GET /items/{id} returns 200 for a known id and 404 otherwise (or the feature is removed if not needed)
+<!-- AC:END -->

--- a/backlog/tasks/task-6 - Guard-against-null-Business-in-BusinessService-gRPC-mappers.md
+++ b/backlog/tasks/task-6 - Guard-against-null-Business-in-BusinessService-gRPC-mappers.md
@@ -1,0 +1,26 @@
+---
+id: TASK-6
+title: Guard against null Business in BusinessService gRPC mappers
+status: To Do
+assignee: []
+created_date: '2026-07-23 04:10'
+labels:
+  - businessservice
+  - bug
+dependencies: []
+priority: medium
+ordinal: 6000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+proto3 singular message fields can be unset, but BusinessMapper dereferences request.Business.* with no null check in CreateBusiness/UpdateBusiness. A missing payload surfaces as a gRPC Unknown/NRE instead of InvalidArgument.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 CreateBusiness and UpdateBusiness return InvalidArgument when the business payload is missing
+- [ ] #2 BusinessMapper no longer throws NullReferenceException on a null Business
+- [ ] #3 Unit test covers the missing-business case
+<!-- AC:END -->

--- a/backlog/tasks/task-7 - Honor-update_mask-in-BusinessService-UpdateBusiness.md
+++ b/backlog/tasks/task-7 - Honor-update_mask-in-BusinessService-UpdateBusiness.md
@@ -1,0 +1,26 @@
+---
+id: TASK-7
+title: Honor update_mask in BusinessService UpdateBusiness
+status: To Do
+assignee: []
+created_date: '2026-07-23 04:10'
+labels:
+  - businessservice
+  - api
+dependencies: []
+priority: medium
+ordinal: 7000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The proto and README advertise partial updates via FieldMask, but UpdateBusinessAsync always overwrites every column, causing silent data loss for callers that send a partial update_mask. Either apply the field mask or remove it from the API and docs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Only fields present in update_mask are written to Postgres
+- [ ] #2 Fields omitted from the mask retain their existing values
+- [ ] #3 update_mask behavior is documented in the BusinessService README (or update_mask is removed from proto/README)
+<!-- AC:END -->

--- a/backlog/tasks/task-8 - Handle-NULL-latitude-longitude-in-BusinessRepository-reads.md
+++ b/backlog/tasks/task-8 - Handle-NULL-latitude-longitude-in-BusinessRepository-reads.md
@@ -1,0 +1,27 @@
+---
+id: TASK-8
+title: Handle NULL latitude/longitude in BusinessRepository reads
+status: To Do
+assignee: []
+created_date: '2026-07-23 04:10'
+labels:
+  - businessservice
+  - bug
+  - database
+dependencies: []
+priority: medium
+ordinal: 8000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+init.sql declares latitude/longitude as nullable DOUBLE PRECISION, but GetBusinessByIdAsync and GetAllBusinessesByIdsAsync call reader.GetDouble unconditionally, throwing InvalidCastException for any row with NULL coordinates. Add NOT NULL to the schema or null-check the reader.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 GetBusinessById and GetAllBusinessesByIds do not throw on NULL latitude/longitude
+- [ ] #2 Schema enforces NOT NULL coordinates or the model represents coordinates as nullable
+- [ ] #3 A test covers a business row with NULL coordinates
+<!-- AC:END -->

--- a/backlog/tasks/task-9 - Wire-BusinessService-into-RestAPI-and-sync-Postgres-Redis-business-data.md
+++ b/backlog/tasks/task-9 - Wire-BusinessService-into-RestAPI-and-sync-Postgres-Redis-business-data.md
@@ -1,0 +1,27 @@
+---
+id: TASK-9
+title: Wire BusinessService into RestAPI and sync Postgres/Redis business data
+status: To Do
+assignee: []
+created_date: '2026-07-23 04:10'
+labels:
+  - backend
+  - architecture
+  - tech-debt
+dependencies: []
+priority: medium
+ordinal: 9000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+RestAPI only has a LocationService gRPC client, so there is no REST path to BusinessService CRUD. Business names live in both Postgres (BusinessService) and Redis (business:{id}, biz:geo), seeded independently with no synchronization, so nearby-search results can drift from the source of truth. Add a BusinessService gRPC client to RestAPI and a propagation/sync mechanism. Complements TASK-1.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 RestAPI has a registered BusinessService gRPC client
+- [ ] #2 Business create/update/delete propagates name and geo data to Redis
+- [ ] #3 Source-of-truth/ownership for business data is documented
+<!-- AC:END -->

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# wt.sh - create a task worktree from the connect-dotnet root (a master checkout).
+#
+# Run from the repo root. Creates a linked worktree under .worktrees/<branch>
+# (gitignored) and optionally marks a Backlog task In Progress.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/wt.sh <branch> [--base <base-branch>] [--task TASK-N]
+
+Creates a git worktree at .worktrees/<branch> from the repo root.
+
+  <branch>        Branch / worktree name (e.g. task-6-null-business-guard)
+  --base          Base branch to fork a NEW branch from (default: master)
+  --task TASK-N   Mark this Backlog task In Progress after creating the worktree
+
+Examples:
+  scripts/wt.sh task-6-null-guard --task TASK-6
+  scripts/wt.sh spike-caching --base master
+EOF
+}
+
+[ $# -ge 1 ] || { usage; exit 1; }
+case "$1" in -h|--help) usage; exit 0 ;; esac
+
+BRANCH="$1"; shift
+BASE="master"; TASK=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base) BASE="${2:?--base needs a value}"; shift 2 ;;
+    --task) TASK="${2:?--task needs a value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+[ -e .git ] || { echo "error: not a git repo root (no .git here)" >&2; exit 1; }
+
+DEST=".worktrees/$BRANCH"
+[ -e "$DEST" ] && { echo "error: $DEST already exists" >&2; exit 1; }
+mkdir -p .worktrees
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  echo "Branch '$BRANCH' exists -> checking it out at $DEST"
+  git worktree add "$DEST" "$BRANCH"
+else
+  git show-ref --verify --quiet "refs/heads/$BASE" \
+    || { echo "error: base branch '$BASE' not found" >&2; exit 1; }
+  echo "Creating new branch '$BRANCH' from '$BASE' at $DEST"
+  git worktree add "$DEST" -b "$BRANCH" "$BASE"
+fi
+
+if [ -n "$TASK" ]; then
+  if command -v backlog >/dev/null 2>&1; then
+    backlog task edit "$TASK" -s "In Progress" >/dev/null \
+      && echo "  $TASK -> In Progress" \
+      || echo "  warn: could not update $TASK" >&2
+  else
+    echo "  warn: 'backlog' not on PATH; skipping task update" >&2
+  fi
+fi
+
+cat <<EOF
+
+Worktree ready: $ROOT/$DEST
+Next steps:
+  cd $DEST                 # work + build + test here (not on master at the root)
+  backlog task view ${TASK:-TASK-N} --plain
+  # once the branch is pushed, tie it to the task (keep existing refs):
+  #   backlog task edit ${TASK:-TASK-N} --ref "https://github.com/tpham2580/connect-dotnet/tree/$BRANCH"
+  # when merged:
+  #   git worktree remove $DEST && git branch -d $BRANCH
+EOF


### PR DESCRIPTION
Adds agent-facing tooling and the Backlog.md taskboard to the repo.

## What's included
- **AGENTS.md** — repo layout (a `master` checkout at the root + linked task worktrees under `.worktrees/`) and the task -> worktree -> Backlog workflow, including the orchestrator convention.
- **scripts/wt.sh** — helper to create a task worktree under `.worktrees/<branch>` from the root (optionally marks a Backlog task In Progress).
- **.github/copilot-instructions.md** — Backlog.md CLI nudge + a repo-layout note for agents.
- **backlog/** — Backlog.md taskboard (config + tasks 1-9).
- **.gitignore** — ignore local `/.worktrees/`.

## Notes
- No application code changes; docs/tooling/taskboard only.
- `.worktrees/` is gitignored (local task worktrees; each task branch is committed on its own).
